### PR TITLE
Destructable enhancements

### DIFF
--- a/Assets/Prefabs/DestructableExample.asset
+++ b/Assets/Prefabs/DestructableExample.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 058afafa72ec9b84b86ae4654ac2134c, type: 3}
+  m_Name: DestructableExample
+  m_EditorClassIdentifier: 
+  element: 0
+  MaxHealth: 0
+  manaDropAmount: 0

--- a/Assets/Prefabs/DestructableExample.asset
+++ b/Assets/Prefabs/DestructableExample.asset
@@ -13,5 +13,5 @@ MonoBehaviour:
   m_Name: DestructableExample
   m_EditorClassIdentifier: 
   element: 0
-  MaxHealth: 0
+  MaxHealth: 5
   manaDropAmount: 0

--- a/Assets/Prefabs/DestructableExample.asset.meta
+++ b/Assets/Prefabs/DestructableExample.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0bc751b904e2eb249ba0d9618a12b993
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/DestructableExample.prefab
+++ b/Assets/Prefabs/DestructableExample.prefab
@@ -102,3 +102,4 @@ MonoBehaviour:
   - {fileID: 21300000, guid: 95b7cc9fcfa53b446a34d400eb4aa858, type: 3}
   - {fileID: 21300000, guid: 07691bcb632930d4283775d9862bdaad, type: 3}
   - {fileID: 21300000, guid: 5a00216fd5d3fb44390dd2effc66e3fc, type: 3}
+  entityData: {fileID: 11400000, guid: 0bc751b904e2eb249ba0d9618a12b993, type: 2}

--- a/Assets/Prefabs/DestructableExample.prefab
+++ b/Assets/Prefabs/DestructableExample.prefab
@@ -102,4 +102,8 @@ MonoBehaviour:
   - {fileID: 21300000, guid: 95b7cc9fcfa53b446a34d400eb4aa858, type: 3}
   - {fileID: 21300000, guid: 07691bcb632930d4283775d9862bdaad, type: 3}
   - {fileID: 21300000, guid: 5a00216fd5d3fb44390dd2effc66e3fc, type: 3}
+  destroyOnEnd: 1
   entityData: {fileID: 11400000, guid: 0bc751b904e2eb249ba0d9618a12b993, type: 2}
+  hitDamageSound: event:/UI/Menu Slider Click
+  hitNoDamageSound: event:/UI/Menu Hover
+  hitBreakSound: event:/UI/Menu Exit

--- a/Assets/Scripts/Destructible.cs
+++ b/Assets/Scripts/Destructible.cs
@@ -8,6 +8,7 @@
 public class Destructible : Entity
 {
     [SerializeField] private Sprite[] sprites; //The different textures go into this array
+    [SerializeField] private bool destroyOnEnd = true;
     [SerializeField] private EntityData entityData;
     
     private float[] _healthPercents;
@@ -21,46 +22,48 @@ public class Destructible : Entity
         health = Mathf.Clamp(health, 0, entityData.MaxHealth);
         _spriteRenderer = gameObject.GetComponent<SpriteRenderer>();
         _spriteRenderer.sprite = sprites[0];
-
         _healthPercents = CreatePercents(sprites.Length);
     }
     
-    //Private method determines the cutoffs on percent the ranges based on the number of Sprites
+    // Determines the cutoffs on percent the ranges based on the number of Sprites
     private static float[] CreatePercents(int numSprites)
     {
         float[] healthPercents = new float[numSprites];
-
-        healthPercents[0] = 1;
-        if (numSprites > 1)
-        {
-            float distance = 1 / ((float) numSprites - 1); //Constant value; Distance from one cutoff to another
-            for (int i = 1; i < numSprites; ++i)
-            {
-                healthPercents[i] = healthPercents[i - 1] - distance;
-            }
-        }
+        float frequencyOfChange = 1 / ((float) numSprites - 1);
+        
+        for (int i = 0; i < healthPercents.Length; i++)
+            healthPercents[i] = 1 - i * frequencyOfChange;
+        
         return healthPercents;
     }
     
-    //Overrides TakeDamage from entity class; will also prompt a change of textures when object is damaged
-    public override void TakeDamage(float baseDamage)
+    public override void TakeDamage(float damage)
     {
-        base.TakeDamage(baseDamage);
+        if (health <= 0 && !destroyOnEnd)
+            return;
+        
+        base.TakeDamage(damage);
         ChangeTextures();
     }
 
-    //Private method which will gauge what texture to display when a health percentage is within a desired range
+    // Gauges what texture to display when a health percentage is within a desired range
     private void ChangeTextures()
     {
+        var curPercent = health / entityData.MaxHealth;
+
         for (int i = 0; i < _healthPercents.Length - 1; ++i)
         {
-            var currPercent = health / entityData.MaxHealth;
-
-            if (currPercent < _healthPercents[i] && currPercent >= _healthPercents[i + 1])
+            if (curPercent < _healthPercents[i] && curPercent >= _healthPercents[i + 1])
             {
                 _spriteRenderer.sprite = sprites[i + 1];
                 break;
             }
         }
+    }
+
+    public override void OnDeath()
+    {
+        if (destroyOnEnd)
+            base.OnDeath();
     }
 }

--- a/Assets/Scripts/Destructible.cs
+++ b/Assets/Scripts/Destructible.cs
@@ -16,7 +16,6 @@ public class Destructible : Entity
     
     [Header("Destructible Sounds")]
     [SerializeField, EventRef] private string hitDamageSound;
-    [SerializeField, EventRef] private string hitNoDamageSound;
     [SerializeField, EventRef] private string hitBreakSound;
     
     [Header("Destructible Events")]
@@ -55,9 +54,14 @@ public class Destructible : Entity
     {
         damageEvent.Invoke(CurrentPercentHealth);
         
-        if (health <= 1 && !destroyOnEnd)
+        if (health <= 2 && !destroyOnEnd)
         {
-            RuntimeManager.PlayOneShotAttached(hitNoDamageSound, gameObject);
+            if (TryGetComponent<Collider2D>(out var collider2d))
+                collider2d.enabled = false;
+            
+            RuntimeManager.PlayOneShotAttached(hitBreakSound, gameObject);
+            health = 1;
+            ChangeTextures();
             return;
         }
         

--- a/Assets/Scripts/Destructible.cs
+++ b/Assets/Scripts/Destructible.cs
@@ -15,6 +15,10 @@ public class Destructible : Entity
 
     private void Start()
     {
+        if (health > entityData.MaxHealth)
+            Debug.LogWarning($"Tried to set health ({health}) greater than the MaxHealth ({entityData.MaxHealth}) for {entityData.name}");
+        
+        health = Mathf.Clamp(health, 0, entityData.MaxHealth);
         _spriteRenderer = gameObject.GetComponent<SpriteRenderer>();
         _spriteRenderer.sprite = sprites[0];
 
@@ -26,10 +30,10 @@ public class Destructible : Entity
     {
         float[] healthPercents = new float[numSprites];
 
-        healthPercents[0] = 100;
+        healthPercents[0] = 1;
         if (numSprites > 1)
         {
-            float distance = 100 / (numSprites - 1); //Constant value; Distance from one cutoff to another
+            float distance = 1 / ((float) numSprites - 1); //Constant value; Distance from one cutoff to another
             for (int i = 1; i < numSprites; ++i)
             {
                 healthPercents[i] = healthPercents[i - 1] - distance;
@@ -50,9 +54,9 @@ public class Destructible : Entity
     {
         for (int i = 0; i < _healthPercents.Length - 1; ++i)
         {
-            var currPercent = health / entityData.MaxHealth * 100;
+            var currPercent = health / entityData.MaxHealth;
 
-            if (currPercent < _healthPercents[i] & currPercent >= _healthPercents[i + 1])
+            if (currPercent < _healthPercents[i] && currPercent >= _healthPercents[i + 1])
             {
                 _spriteRenderer.sprite = sprites[i + 1];
                 break;

--- a/Assets/Scripts/Destructible.cs
+++ b/Assets/Scripts/Destructible.cs
@@ -1,5 +1,6 @@
 ﻿using FMODUnity;
 using UnityEngine;
+using UnityEngine.Events;
 
 /***********************************************************
  * Script will change an object's texture to appear damage
@@ -17,6 +18,10 @@ public class Destructible : Entity
     [SerializeField, EventRef] private string hitDamageSound;
     [SerializeField, EventRef] private string hitNoDamageSound;
     [SerializeField, EventRef] private string hitBreakSound;
+    
+    [Header("Destructible Events")]
+    [SerializeField] private UnityEvent damageEvent;
+    [SerializeField] private UnityEvent breakEvent;
     
     private float[] _healthPercents;
     private SpriteRenderer _spriteRenderer; 
@@ -46,6 +51,8 @@ public class Destructible : Entity
     
     public override void TakeDamage(float damage)
     {
+        damageEvent.Invoke();
+        
         if (health <= 1 && !destroyOnEnd)
         {
             RuntimeManager.PlayOneShotAttached(hitNoDamageSound, gameObject);
@@ -76,6 +83,7 @@ public class Destructible : Entity
     {
         if (destroyOnEnd)
         {
+            breakEvent.Invoke();
             RuntimeManager.PlayOneShotAttached(hitBreakSound, gameObject);
             base.OnDeath();
         }

--- a/Assets/Scripts/Destructible.cs
+++ b/Assets/Scripts/Destructible.cs
@@ -20,11 +20,13 @@ public class Destructible : Entity
     [SerializeField, EventRef] private string hitBreakSound;
     
     [Header("Destructible Events")]
-    [SerializeField] private UnityEvent damageEvent;
+    [SerializeField] private UnityEvent<float> damageEvent; // Passes the current percent damage, as a 01 float
     [SerializeField] private UnityEvent breakEvent;
     
     private float[] _healthPercents;
     private SpriteRenderer _spriteRenderer; 
+    
+    public float CurrentPercentHealth => health / entityData.MaxHealth;
 
     private void Start()
     {
@@ -51,7 +53,7 @@ public class Destructible : Entity
     
     public override void TakeDamage(float damage)
     {
-        damageEvent.Invoke();
+        damageEvent.Invoke(CurrentPercentHealth);
         
         if (health <= 1 && !destroyOnEnd)
         {
@@ -67,11 +69,9 @@ public class Destructible : Entity
     // Gauges what texture to display when a health percentage is within a desired range
     private void ChangeTextures()
     {
-        var curPercent = health / entityData.MaxHealth;
-
         for (int i = 0; i < _healthPercents.Length - 1; ++i)
         {
-            if (curPercent < _healthPercents[i] && curPercent >= _healthPercents[i + 1])
+            if (CurrentPercentHealth < _healthPercents[i] && CurrentPercentHealth >= _healthPercents[i + 1])
             {
                 _spriteRenderer.sprite = sprites[i + 1];
                 break;

--- a/Assets/Scripts/Destructible.cs
+++ b/Assets/Scripts/Destructible.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using FMODUnity;
+using UnityEngine;
 
 /***********************************************************
  * Script will change an object's texture to appear damage
@@ -7,9 +8,15 @@
  ***********************************************************/
 public class Destructible : Entity
 {
+    [Header("Destructible Settings")]
     [SerializeField] private Sprite[] sprites; //The different textures go into this array
     [SerializeField] private bool destroyOnEnd = true;
     [SerializeField] private EntityData entityData;
+    
+    [Header("Destructible Sounds")]
+    [SerializeField, EventRef] private string hitDamageSound;
+    [SerializeField, EventRef] private string hitNoDamageSound;
+    [SerializeField, EventRef] private string hitBreakSound;
     
     private float[] _healthPercents;
     private SpriteRenderer _spriteRenderer; 
@@ -39,10 +46,14 @@ public class Destructible : Entity
     
     public override void TakeDamage(float damage)
     {
-        if (health <= 0 && !destroyOnEnd)
+        if (health <= 1 && !destroyOnEnd)
+        {
+            RuntimeManager.PlayOneShotAttached(hitNoDamageSound, gameObject);
             return;
+        }
         
         base.TakeDamage(damage);
+        RuntimeManager.PlayOneShotAttached(hitDamageSound, gameObject);
         ChangeTextures();
     }
 
@@ -64,6 +75,9 @@ public class Destructible : Entity
     public override void OnDeath()
     {
         if (destroyOnEnd)
+        {
+            RuntimeManager.PlayOneShotAttached(hitBreakSound, gameObject);
             base.OnDeath();
+        }
     }
 }

--- a/Assets/Scripts/Destructible.cs
+++ b/Assets/Scripts/Destructible.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 /***********************************************************
  * Script will change an object's texture to appear damage
@@ -9,43 +7,35 @@ using UnityEngine;
  ***********************************************************/
 public class Destructible : Entity
 {
-    public Sprite[] sprites; //The different textures go into this array
-    private float[] healthPercents;
-    private float maxHealth; //Constant value; an objects maximum health
-    private SpriteRenderer spriteRenderer; 
+    [SerializeField] private Sprite[] sprites; //The different textures go into this array
+    [SerializeField] private EntityData entityData;
+    
+    private float[] _healthPercents;
+    private SpriteRenderer _spriteRenderer; 
 
-    //Private method determines the cutoffs on percent the ranges based on the number of Sprites
-    private float[] CreatePercents(int numSprites)
+    private void Start()
     {
-        float[] HealthPercents = new float[numSprites];
+        _spriteRenderer = gameObject.GetComponent<SpriteRenderer>();
+        _spriteRenderer.sprite = sprites[0];
 
-        HealthPercents[0] = 100;
+        _healthPercents = CreatePercents(sprites.Length);
+    }
+    
+    //Private method determines the cutoffs on percent the ranges based on the number of Sprites
+    private static float[] CreatePercents(int numSprites)
+    {
+        float[] healthPercents = new float[numSprites];
+
+        healthPercents[0] = 100;
         if (numSprites > 1)
         {
             float distance = 100 / (numSprites - 1); //Constant value; Distance from one cutoff to another
             for (int i = 1; i < numSprites; ++i)
             {
-                HealthPercents[i] = HealthPercents[i - 1] - distance;
+                healthPercents[i] = healthPercents[i - 1] - distance;
             }
         }
-        return HealthPercents;
-    }
-
-    //Private method which will gauge what texture to display when a health percentage is within a desired range
-    private void ChangeTextures()
-    {
-        float currPercent;
-
-        for (int i = 0; i < healthPercents.Length - 1; ++i)
-        {
-            currPercent = base.health / maxHealth * 100;
-
-            if (currPercent < healthPercents[i] & currPercent >= healthPercents[i + 1])
-            {
-                spriteRenderer.sprite = sprites[i + 1];
-                break;
-            }
-        }
+        return healthPercents;
     }
     
     //Overrides TakeDamage from entity class; will also prompt a change of textures when object is damaged
@@ -55,13 +45,18 @@ public class Destructible : Entity
         ChangeTextures();
     }
 
-    // Start is called before the first frame update
-    void Start()
+    //Private method which will gauge what texture to display when a health percentage is within a desired range
+    private void ChangeTextures()
     {
-        spriteRenderer = gameObject.GetComponent<SpriteRenderer>();
-        healthPercents = CreatePercents(sprites.Length);
-        spriteRenderer.sprite = sprites[0];
-        maxHealth = base.health;
-    }
+        for (int i = 0; i < _healthPercents.Length - 1; ++i)
+        {
+            var currPercent = health / entityData.MaxHealth * 100;
 
+            if (currPercent < _healthPercents[i] & currPercent >= _healthPercents[i + 1])
+            {
+                _spriteRenderer.sprite = sprites[i + 1];
+                break;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Expanded the Destructible functionality in several ways:
- Incorporated EntityData into calculations for Max Health.
- Added the option for a Destructible to remain on final sprite instead of being destroyed.
- Added UnityEvents for damage and breaking.
- Added sound effects for damaging and breaking.

Closes #106 