### PR TITLE
Fix Slide Ability able to be used when locked

### DIFF
--- a/Assets/Scripts/SlideAbility.cs
+++ b/Assets/Scripts/SlideAbility.cs
@@ -26,6 +26,9 @@ public class SlideAbility : Ability
         if(!canSlide)
             return;
 
+        if(Player.lockControls)
+            return;
+
         int direction = Player.primaryStick.x >= 0 ? 1 : -1;
         if(Player.primaryStick.x == 0){
             direction = Player.facingDirection;


### PR DESCRIPTION
Quick fix for the slide ability, now you cannot slide if the player's controls have been locked